### PR TITLE
Fix Freepik task id parsing

### DIFF
--- a/server/freepik-api.ts
+++ b/server/freepik-api.ts
@@ -14,14 +14,16 @@ export interface FreepikVideoRequest {
 
 export interface FreepikVideoResponse {
   data: [{
-    id: string;
+    id?: string;
+    task_id?: string;
     status: string;
   }];
 }
 
 export interface FreepikStatusResponse {
   data: [{
-    id: string;
+    id?: string;
+    task_id?: string;
     status: string;
     generated?: string;
     generated_files?: string[];
@@ -60,9 +62,12 @@ export class FreepikAPI {
         }
       );
 
-      if (response.data?.data?.[0]?.id) {
-        console.log('Successfully created Freepik task:', response.data.data[0].id);
-        return response.data.data[0].id;
+      const taskData = response.data?.data?.[0];
+      const taskId = taskData?.task_id || taskData?.id;
+
+      if (taskId) {
+        console.log('Successfully created Freepik task:', taskId);
+        return taskId;
       } else {
         throw new Error('Invalid response from Freepik API');
       }


### PR DESCRIPTION
## Summary
- update Freepik API client to accept either `task_id` or `id` from task creation responses
- relax status response typing to support `task_id` while preserving status, generated video data

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_b_68d4589d6b30832aa1100151568b0667